### PR TITLE
fix: correct plan output parsing regex to match actual OpenTofu format

### DIFF
--- a/src/tofu.ts
+++ b/src/tofu.ts
@@ -135,16 +135,18 @@ export class Tofu {
       const { stdout } = await this.runCommand(args);
 
       // Parse the plan output to extract changes
-      const addMatch = stdout.match(/Plan: (\d+) to add/);
-      const changeMatch = stdout.match(/(\d+) to change/);
-      const destroyMatch = stdout.match(/(\d+) to destroy/);
+      // OpenTofu output format: "Plan: X to add, Y to change, Z to destroy."
+      // Strip ANSI escape codes first to handle colored output
+      // eslint-disable-next-line no-control-regex
+      const cleanOutput = stdout.replace(/\u001b\[[0-9;]*m/g, '');
+      const planMatch = cleanOutput.match(/Plan:\s*(\d+)\s+to\s+add,\s*(\d+)\s+to\s+change,\s*(\d+)\s+to\s+destroy\./);
 
       return {
         summary: 'Plan generated successfully',
         changes: {
-          add: addMatch ? parseInt(addMatch[1], 10) : 0,
-          change: changeMatch ? parseInt(changeMatch[1], 10) : 0,
-          destroy: destroyMatch ? parseInt(destroyMatch[1], 10) : 0,
+          add: planMatch ? parseInt(planMatch[1], 10) : 0,
+          change: planMatch ? parseInt(planMatch[2], 10) : 0,
+          destroy: planMatch ? parseInt(planMatch[3], 10) : 0,
         },
         raw: stdout,
       };

--- a/tests/tofu.test.ts
+++ b/tests/tofu.test.ts
@@ -350,6 +350,21 @@ describe('Tofu', () => {
     ], expect.any(Object));
   });
 
+  test('should parse plan output with ANSI color codes', async () => {
+    (execa as jest.Mock).mockResolvedValueOnce({
+      stdout: '\u001b[1mPlan:\u001b[0m 3 to add, 1 to change, 2 to destroy.\n\nSome other output...',
+      stderr: '',
+      all: '\u001b[1mPlan:\u001b[0m 3 to add, 1 to change, 2 to destroy.\n\nSome other output...'
+    });
+    
+    const plan = await tofu.plan();
+    expect(plan.changes).toEqual({
+      add: 3,
+      change: 1,
+      destroy: 2
+    });
+  });
+
   test('should apply changes', async () => {
     (execa as jest.Mock).mockResolvedValueOnce({
       stdout: 'Apply complete! Resources: 1 added, 0 changed, 0 destroyed.',


### PR DESCRIPTION
- Fix regex patterns to properly parse OpenTofu plan output
- Handle ANSI color codes in plan output by stripping them before parsing
- Use single regex to capture all three values (add, change, destroy) from the 'Plan: X to add, Y to change, Z to destroy.' format
- Add test case for ANSI color code handling
- Add ESLint disable comment for control character regex

The previous regex patterns were incorrect and would not properly parse real OpenTofu output, especially when colors are enabled. This fix ensures reliable parsing of plan results regardless of terminal color settings.